### PR TITLE
Add support for Multiple Addresses in a ServiceEntry and Filtering for non services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 # Avoid committing pubspec.lock for library packages; see
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock
+/.idea

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,5 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mdns_dart
 description: A comprehensive mDNS (Multicast DNS) service discovery and advertisement library for Dart, ported from HashiCorp Go implementation.
-version: 1.0.5
+version: 1.1.0
 homepage: https://github.com/animeshxd/mdns_dart
 repository: https://github.com/animeshxd/mdns_dart
 topics:


### PR DESCRIPTION
Great libarary by the way, but added two things that its missing to be comparable to NSD or others.

mDNS clients can return more than one record and your system will log it, but it only ever returned the IP of the first match, this one maintains compatibility but also adds the rest to a list of IPs.

There was also a bug where this would return other services if something else on the network did a query at the same time, thus the ServiceEntry Filter at the end.