### PR TITLE
Fix mDNS integration tests by enabling reusePort in client

### DIFF
--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -52,6 +52,7 @@ void main() {
       final results = await MDNSClient.discover(
         '_test._tcp',
         timeout: const Duration(seconds: 1),
+        reusePort: true,
       );
 
       expect(results, isNotEmpty,
@@ -74,6 +75,7 @@ void main() {
       final results = await MDNSClient.discover(
         '_nonexistent._tcp',
         timeout: const Duration(seconds: 1),
+        reusePort: true,
       );
 
       expect(results, isEmpty,


### PR DESCRIPTION
Enable reusePort: true for MDNSClient in integration_test.dart. This allows the client to bind to port 5353 alongside the MDNSServer in the same process, fixing binding failures on macOS.