### PR TITLE
Clear stale IP addresses when SRV target host changes

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -811,6 +811,15 @@ class QuerySession {
           _log(
             'Processing SRV record: ${srv.name} -> ${srv.target}:${srv.port} (priority: ${srv.priority}, weight: ${srv.weight})',
           );
+          // Clear stale IPs when the SRV target host changes, as the old
+          // addresses belong to a different host and are no longer valid.
+          if (entry.host != srv.target && entry.allAddresses.isNotEmpty) {
+            _log(
+              'SRV target changed from ${entry.host} to ${srv.target}, clearing stale addresses',
+            );
+            entry.addrsV4 = null;
+            entry.addrsV6 = null;
+          }
           entry.host = srv.target;
           entry.port = srv.port;
           break;

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -87,8 +87,7 @@ void main() {
       expect(results, isEmpty);
     });
 
-    // The server should handle conflicting instance names.
-    test('merges IPs when service instance host changes', () {
+    test('clears stale IPs when SRV host changes', () {
       final session = QuerySession(service: '_http._tcp');
 
       // 1. Initial discovery of s1 at h1
@@ -116,7 +115,7 @@ void main() {
         contains('1.1.1.1'),
       );
 
-      // 2. Service "moves" to h2 or another server announces s1 at h2
+      // 2. Service "moves" to h2 — old IPs must be cleared
       final records2 = [
         SRVRecord(
           name: 's1._http._tcp.local.',
@@ -129,14 +128,13 @@ void main() {
         ARecord(name: 'h2.local.', address: '2.2.2.2', ttl: 120),
       ];
 
-      // No new emission expected as it was already complete
       session.addRecords(records2);
 
       final entry = results1.first;
       final addresses = entry.allAddresses.map((a) => a.address).toList();
 
-      // Old behavior: IPs are accumulated/merged
-      expect(addresses, contains('1.1.1.1'));
+      // Stale IPs from h1 must be gone, only h2's IP should remain
+      expect(addresses, isNot(contains('1.1.1.1')));
       expect(addresses, contains('2.2.2.2'));
       expect(entry.host, 'h2.local.');
     });


### PR DESCRIPTION
## Summary
- When a service instance receives a new SRV record pointing to a different host, stale IP addresses from the previous host are now cleared before updating the target
- Previously, old IPs accumulated across host changes, leading to invalid IP/host combinations in `ServiceEntry`
- The fix checks if the SRV target has changed and the entry already has addresses — only then clears `addrsV4`/`addrsV6`

## Test plan
- [x] Updated existing test to verify old IPs are cleared (not merged) on host change
- [x] Verified retransmission of same SRV record does not clear IPs
- [x] Verified first SRV record on new entry does not trigger false clearing
- [x] Verified dual-stack (IPv4 + IPv6) scenario still works
- [x] All 98 tests pass
- [x] `dart analyze` clean

Fixes #8