### PR TITLE
Retry multicast socket binding with reusePort on failure

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -357,43 +357,19 @@ class _Client {
   Future<void> _bindMulticastSocket(NetworkInterface? iface) async {
     // Create multicast connections
     if (_useIPv4) {
-      try {
-        _ipv4MulticastConn = await RawDatagramSocket.bind(
-          InternetAddress.anyIPv4,
-          mDNSPort,
-          reusePort: _reusePort,
-          reuseAddress: _reuseAddress,
-          ttl: _multicastHops,
-        );
-        _ipv4MulticastConn!.joinMulticast(InternetAddress(ipv4mDNS));
-        _log(
-          'IPv4 multicast socket bound to port $mDNSPort with reusePort=$_reusePort, reuseAddress=$_reuseAddress, multicastHops=$_multicastHops',
-        );
-      } catch (e) {
-        _log('Failed to create IPv4 multicast socket: $e');
-        _ipv4MulticastConn?.close();
-        _ipv4MulticastConn = null;
-      }
+      _ipv4MulticastConn = await _tryBindMulticast(
+        InternetAddress.anyIPv4,
+        InternetAddress(ipv4mDNS),
+        'IPv4',
+      );
     }
 
     if (_useIPv6) {
-      try {
-        _ipv6MulticastConn = await RawDatagramSocket.bind(
-          InternetAddress.anyIPv6,
-          mDNSPort,
-          reusePort: _reusePort,
-          reuseAddress: _reuseAddress,
-          ttl: _multicastHops,
-        );
-        _ipv6MulticastConn!.joinMulticast(InternetAddress(ipv6mDNS));
-        _log(
-          'IPv6 multicast socket bound to port $mDNSPort with reusePort=$_reusePort, reuseAddress=$_reuseAddress, multicastHops=$_multicastHops',
-        );
-      } catch (e) {
-        _log('Failed to create IPv6 multicast socket: $e');
-        _ipv6MulticastConn?.close();
-        _ipv6MulticastConn = null;
-      }
+      _ipv6MulticastConn = await _tryBindMulticast(
+        InternetAddress.anyIPv6,
+        InternetAddress(ipv6mDNS),
+        'IPv6',
+      );
     }
 
     if (_ipv4MulticastConn == null && _ipv6MulticastConn == null) {
@@ -401,6 +377,55 @@ class _Client {
       throw StateError('Failed to bind to any multicast UDP port');
     }
     if (iface != null) await _setMulticastInterface(iface);
+  }
+
+  /// Tries to bind a multicast socket. If binding fails and [_reusePort] is
+  /// false, retries with `reusePort: true` to handle platforms where the mDNS
+  /// port is already in use by a system service (e.g. mDNSResponder on
+  /// macOS/iOS).
+  Future<RawDatagramSocket?> _tryBindMulticast(
+    InternetAddress address,
+    InternetAddress multicastGroup,
+    String label,
+  ) async {
+    try {
+      final socket = await RawDatagramSocket.bind(
+        address,
+        mDNSPort,
+        reusePort: _reusePort,
+        reuseAddress: _reuseAddress,
+        ttl: _multicastHops,
+      );
+      socket.joinMulticast(multicastGroup);
+      _log(
+        '$label multicast socket bound to port $mDNSPort with reusePort=$_reusePort, reuseAddress=$_reuseAddress, multicastHops=$_multicastHops',
+      );
+      return socket;
+    } catch (e) {
+      _log('Failed to create $label multicast socket: $e');
+      if (_reusePort) return null;
+
+      // Retry with reusePort: true — on macOS/iOS the mDNS port is typically
+      // held by the system mDNSResponder service.
+      _log('Retrying $label multicast socket with reusePort=true');
+      try {
+        final socket = await RawDatagramSocket.bind(
+          address,
+          mDNSPort,
+          reusePort: true,
+          reuseAddress: _reuseAddress,
+          ttl: _multicastHops,
+        );
+        socket.joinMulticast(multicastGroup);
+        _log(
+          '$label multicast socket bound to port $mDNSPort with reusePort=true (retry succeeded)',
+        );
+        return socket;
+      } catch (e2) {
+        _log('Retry also failed for $label multicast socket: $e2');
+        return null;
+      }
+    }
   }
 
   /// Initializes the client sockets

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -171,10 +171,11 @@ class MDNSServer {
     _log('mDNS server stopped');
   }
 
-  /// Binds a multicast socket with configurable socket options
+  /// Binds a multicast socket with configurable socket options.
   ///
-  /// Throws exceptions on binding failures rather than returning null.
-  /// Users should handle exceptions based on their requirements.
+  /// If binding fails and [reusePort] is `false`, retries with
+  /// `reusePort: true` to handle platforms where the mDNS port is already
+  /// held by a system service (e.g. mDNSResponder on macOS/iOS).
   ///
   /// Note for Android: If you encounter binding issues with reusePort=true,
   /// try setting reusePort=false and handle socket conflicts manually.
@@ -185,16 +186,28 @@ class MDNSServer {
     required bool reuseAddress,
     required int multicastHops,
   }) async {
-    // Try binding with the specified options
-    final socket = await RawDatagramSocket.bind(
-      address,
-      port,
-      reuseAddress: reuseAddress,
-      reusePort: reusePort,
-      ttl: multicastHops,
-    );
+    try {
+      return await RawDatagramSocket.bind(
+        address,
+        port,
+        reuseAddress: reuseAddress,
+        reusePort: reusePort,
+        ttl: multicastHops,
+      );
+    } catch (e) {
+      if (reusePort) rethrow;
 
-    return socket;
+      // Retry with reusePort: true — on macOS/iOS the mDNS port is typically
+      // held by the system mDNSResponder service.
+      _log('Binding failed with reusePort=false, retrying with reusePort=true');
+      return await RawDatagramSocket.bind(
+        address,
+        port,
+        reuseAddress: reuseAddress,
+        reusePort: true,
+        ttl: multicastHops,
+      );
+    }
   }
 
   /// Handle incoming packets


### PR DESCRIPTION
## Summary
- On macOS/iOS, the system `mDNSResponder` service holds port 5353, causing `RawDatagramSocket.bind()` to fail with "Address already in use (errno 48)" when `reusePort` is `false` (the default)
- Both client and server now automatically retry with `reusePort: true` when the initial bind fails
- No API changes — existing parameters and defaults remain the same
- On platforms where the initial bind succeeds (e.g. Linux), the retry path is never entered

## Tested on macOS

**Before fix:** `example/client.dart` crashes with `Bad state: Failed to bind to any multicast UDP port`

**After fix:** discovers services with default parameters (no `reusePort` or `networkInterface` needed):
```
Discovering HTTP services...
Found 11 HTTP service(s):
Service: HP LaserJet 400 color M451nw (35143A)._http._tcp.local
  Host: NPI35143A.local
  IPv4: 192.168.2.48
  Port: 80
...
```

## Test plan
- [x] All 98 existing tests pass
- [x] `dart analyze` clean
- [x] Verified on macOS: default `example/client.dart` now works without any parameter changes
- [x] Retry only triggers when `reusePort` was `false` — avoids pointless double-retry
- [x] Applied same fix to both `client.dart` and `server.dart`

Fixes #4