### PR TITLE
Add goodbye packet support (RFC 6762 Section 10.1)

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -796,6 +796,13 @@ class QuerySession {
     final newResults = <ServiceEntry>[];
 
     for (final record in records) {
+      // Handle goodbye packets (RFC 6762 Section 10.1): TTL=0 means
+      // the service is going away and should be removed from cache.
+      if (record.ttl == 0) {
+        _handleGoodbye(record);
+        continue;
+      }
+
       final entry = _ensureEntry(record.name);
       entry.host = entry.host.isEmpty ? record.name : entry.host;
 
@@ -882,6 +889,28 @@ class QuerySession {
       return true;
     }
     return false;
+  }
+
+  /// Handles a goodbye record (TTL=0) by removing the service from tracking,
+  /// allowing it to be re-discovered if it comes back.
+  void _handleGoodbye(DNSResourceRecord record) {
+    _log('Received goodbye (TTL=0) for: ${record.name}');
+
+    if (record case PTRRecord ptr) {
+      // PTR goodbye: remove both the alias and the target entry.
+      _inProgress.remove(ptr.name);
+      final entry = _inProgress.remove(ptr.target);
+      if (entry != null) {
+        _completedServices.remove(entry.name);
+      }
+      _completedServices.remove(ptr.target);
+    } else {
+      final entry = _inProgress.remove(record.name);
+      if (entry != null) {
+        _completedServices.remove(entry.name);
+      }
+      _completedServices.remove(record.name);
+    }
   }
 
   ServiceEntry _ensureEntry(String name) {

--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -150,10 +150,17 @@ class MDNSServer {
   }
 
   /// Stop the mDNS server
+  ///
+  /// Sends goodbye packets (TTL=0) before closing sockets, as specified
+  /// by RFC 6762 Section 10.1, so that other mDNS clients on the network
+  /// can immediately remove the service from their caches.
   Future<void> stop() async {
     if (!_isRunning) return;
 
     _log('Stopping mDNS server...');
+
+    // Send goodbye packets before closing sockets
+    _sendGoodbye();
 
     // Cancel all subscriptions
     for (final subscription in _subscriptions) {
@@ -169,6 +176,40 @@ class MDNSServer {
 
     _isRunning = false;
     _log('mDNS server stopped');
+  }
+
+  /// Sends goodbye packets (all records with TTL=0) via multicast.
+  void _sendGoodbye() {
+    final records = _config.zone.goodbyeRecords();
+    if (records.isEmpty) return;
+
+    _log('Sending ${records.length} goodbye records');
+
+    int flags = 0;
+    flags |= DNSFlags.QR;
+    flags |= DNSFlags.AA;
+
+    final message = DNSMessage(
+      header: DNSHeader(
+        id: 0,
+        flags: flags,
+        qdcount: 0,
+        ancount: records.length,
+        nscount: 0,
+        arcount: 0,
+      ),
+      questions: [],
+      answers: records,
+      authority: [],
+      additional: [],
+    );
+
+    if (_ipv4Socket != null) {
+      _sendResponse(message, _ipv4Socket!, isUnicast: false);
+    }
+    if (_ipv6Socket != null) {
+      _sendResponse(message, _ipv6Socket!, isUnicast: false);
+    }
   }
 
   /// Binds a multicast socket with configurable socket options

--- a/lib/src/zone.dart
+++ b/lib/src/zone.dart
@@ -15,6 +15,10 @@ const int defaultTTL = 120;
 abstract class Zone {
   /// Returns DNS records in response to a DNS question
   List<DNSResourceRecord> records(DNSQuestion question);
+
+  /// Returns all records with TTL=0 for sending goodbye packets
+  /// (RFC 6762 Section 10.1).
+  List<DNSResourceRecord> goodbyeRecords() => [];
 }
 
 /// mDNS service implementation that can serve records for a named service
@@ -358,6 +362,48 @@ class MDNSService implements Zone {
     }
   }
 
+  @override
+  List<DNSResourceRecord> goodbyeRecords() {
+    return [
+      PTRRecord(
+        name: serviceAddr,
+        target: instanceAddr,
+        dnsClass: DNSClass.IN,
+        ttl: 0,
+      ),
+      SRVRecord(
+        name: instanceAddr,
+        priority: 10,
+        weight: 1,
+        port: port,
+        target: hostName,
+        dnsClass: DNSClass.IN,
+        ttl: 0,
+      ),
+      TXTRecord(
+        name: instanceAddr,
+        strings: txt,
+        dnsClass: DNSClass.IN,
+        ttl: 0,
+      ),
+      for (final ip in ips)
+        if (ip.type == InternetAddressType.IPv4)
+          ARecord(
+            name: hostName,
+            address: ip.address,
+            dnsClass: DNSClass.IN,
+            ttl: 0,
+          )
+        else
+          AAAARecord(
+            name: hostName,
+            address: ip.address,
+            dnsClass: DNSClass.IN,
+            ttl: 0,
+          ),
+    ];
+  }
+
   /// Creates TXT record strings from key-value pairs
   static List<String> createTXTRecords(Map<String, String> data) {
     return data.entries.map((entry) => '${entry.key}=${entry.value}').toList();
@@ -414,6 +460,11 @@ class MultiServiceZone implements Zone {
     }
 
     return allRecords;
+  }
+
+  @override
+  List<DNSResourceRecord> goodbyeRecords() {
+    return _services.expand((s) => s.goodbyeRecords()).toList();
   }
 
   /// Clears all services

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -301,5 +301,64 @@ void main() {
       expect(results, hasLength(1));
       expect(results.first.name, 'web._http._tcp.local.');
     });
+
+    test('removes service on goodbye packet (TTL=0)', () {
+      final session = QuerySession(service: '_http._tcp');
+
+      // 1. Discover a service
+      final records = [
+        PTRRecord(
+          name: '_http._tcp.local.',
+          target: 's1._http._tcp.local.',
+          ttl: 120,
+        ),
+        SRVRecord(
+          name: 's1._http._tcp.local.',
+          target: 'h1.local.',
+          port: 80,
+          priority: 0,
+          weight: 0,
+          ttl: 120,
+        ),
+        TXTRecord(name: 's1._http._tcp.local.', strings: [''], ttl: 120),
+        ARecord(name: 'h1.local.', address: '1.1.1.1', ttl: 120),
+      ];
+
+      var results = session.addRecords(records);
+      expect(results, hasLength(1));
+
+      // 2. Re-sending same records should not re-emit (deduplication)
+      results = session.addRecords(records);
+      expect(results, isEmpty);
+
+      // 3. Receive goodbye packet (TTL=0) for the service
+      session.addRecords([
+        PTRRecord(
+          name: '_http._tcp.local.',
+          target: 's1._http._tcp.local.',
+          ttl: 0,
+        ),
+      ]);
+
+      // 4. Service should be re-discoverable after goodbye
+      results = session.addRecords(records);
+      expect(results, hasLength(1));
+      expect(results.first.name, 's1._http._tcp.local.');
+    });
+
+    test('ignores goodbye for unknown service', () {
+      final session = QuerySession(service: '_http._tcp');
+
+      // Goodbye for a service we never discovered — should not throw
+      final results = session.addRecords([
+        PTRRecord(
+          name: '_http._tcp.local.',
+          target: 'unknown._http._tcp.local.',
+          ttl: 0,
+        ),
+      ]);
+
+      expect(results, isEmpty);
+    });
   });
 }

--- a/test/zone_test.dart
+++ b/test/zone_test.dart
@@ -416,6 +416,52 @@ void main() {
       });
     });
 
+    group('Goodbye records', () {
+      test('generates all records with TTL=0', () {
+        final records = service.goodbyeRecords();
+
+        // Should have PTR + SRV + TXT + A + AAAA = 5 records
+        expect(records, hasLength(5));
+
+        // All TTLs must be 0
+        for (final record in records) {
+          expect(record.ttl, equals(0), reason: '${record.runtimeType} TTL');
+        }
+
+        // Verify record types
+        expect(records.whereType<PTRRecord>(), hasLength(1));
+        expect(records.whereType<SRVRecord>(), hasLength(1));
+        expect(records.whereType<TXTRecord>(), hasLength(1));
+        expect(records.whereType<ARecord>(), hasLength(1));
+        expect(records.whereType<AAAARecord>(), hasLength(1));
+      });
+
+      test('MultiServiceZone collects goodbye records from all services', () {
+        final zone = MultiServiceZone();
+        zone.addService(service);
+
+        final service2 = MDNSService(
+          instance: 'Web Server',
+          service: '_http._tcp.',
+          domain: 'local.',
+          hostName: 'web.local.',
+          port: 80,
+          ips: [InternetAddress('10.0.0.1')],
+          txt: ['path=/'],
+        );
+        zone.addService(service2);
+
+        final records = zone.goodbyeRecords();
+
+        // service1: PTR + SRV + TXT + A + AAAA = 5
+        // service2: PTR + SRV + TXT + A = 4
+        expect(records, hasLength(9));
+        for (final record in records) {
+          expect(record.ttl, equals(0));
+        }
+      });
+    });
+
     group('TXT record helpers', () {
       test('createTXTRecords formats correctly', () {
         final map = {'key1': 'val1', 'key2': ''};


### PR DESCRIPTION
## Summary
- **Server**: `stop()` now sends goodbye packets (all records with TTL=0) via multicast before closing sockets, allowing other clients on the network to immediately remove the service from their caches
- **Client**: `QuerySession` detects incoming TTL=0 records and removes the service from tracking, enabling re-discovery if the service comes back
- Added `goodbyeRecords()` to `Zone`, `MDNSService`, and `MultiServiceZone`

## Test plan
- [x] All 102 tests pass (4 new)
- [x] `dart analyze` clean
- [x] Goodbye on client side: service removed and re-discoverable after TTL=0 PTR
- [x] Goodbye for unknown service: no crash
- [x] Zone goodbye records: all record types generated with TTL=0
- [x] MultiServiceZone: collects goodbye records from all services
- [x] Edge cases verified: IPv6-only server, empty zone, mid-assembly goodbye