### PR TITLE
Support Dart 3.13+

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -294,9 +294,10 @@ class _Client {
 
     if (iface != null) {
       _log('Binding unicast sockets to interface: ${iface.name}');
-      // try {
+
+      final addresses = iface.addresses.cast<InternetAddress>();
       if (_useIPv4) {
-        ipv4Addr = iface.addresses.firstWhere(
+        ipv4Addr = addresses.firstWhere(
           (addr) => addr.type == InternetAddressType.IPv4,
           orElse: () {
             _log(
@@ -308,7 +309,7 @@ class _Client {
       }
 
       if (_useIPv6) {
-        ipv6Addr = iface.addresses.firstWhere(
+        ipv6Addr = addresses.firstWhere(
           (addr) => addr.type == InternetAddressType.IPv6,
           orElse: () {
             _log(


### PR DESCRIPTION
`NetworkInterface.addresses` now returns List<InterfaceAddress> instead of `List<InternetAddress>` in Dart 3.13+ ([source](https://dart.dev/resources/breaking-changes#dart-io))

Every `InterfaceAddress` implements `InternetAddress` so a simple cast is sufficient.

- https://github.com/dart-lang/sdk/issues/63216

This should be backward-compatible (already of type `InternetAddress`). All Dart unit tests passed.
